### PR TITLE
Updated to Secure URL

### DIFF
--- a/src/Awis.php
+++ b/src/Awis.php
@@ -8,7 +8,7 @@ class Awis {
     
     protected $accessKeyId;
     protected $secretAccessKey;
-    protected $endPoint = "http://awis.amazonaws.com/";
+    protected $endPoint = "https://awis.amazonaws.com/";
     protected $dt;
     protected $signatureMethod = "HmacSHA256";
     protected $signatureVersion = 2;


### PR DESCRIPTION
As per email from Amazon Aug 11 2017:
In our ongoing effort to improve security we plan to disable the HTTP endpoint for AWIS and Alexa TopSites APIs on Thursday August 24, 2017. Please update your code to use the HTTPS endpoint before that time. The only modification required is to change any reference of "http://" to "https://" in your requests. If you have any questions, please reference our updated code samples:

• AWIS - https://aws.amazon.com/code/AWIS/
• Alexa TopSites - https://aws.amazon.com/code/Alexa-Top-Sites/